### PR TITLE
implement logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ selenium-debug.log
 # Golang
 Hacksite
 database.db
+logs/
 
 # extras
 hacksite.zip

--- a/environments/dev.env.json
+++ b/environments/dev.env.json
@@ -1,6 +1,11 @@
 {
-  "KeyLocation": "certs/key.pem",
-  "CertLocation": "certs/cert.pem",
-  "Port": ":5000",
-  "WebFileLocation": "./webdist"
+  "Server": {
+    "KeyLocation": "certs/key.pem",
+    "CertLocation": "certs/cert.pem",
+    "Port": ":5000",
+    "WebFileLocation": "./webdist"
+  },
+  "Logger": {
+    "LogFileLocation": "./logs"
+  }
 }

--- a/environments/test.env.json
+++ b/environments/test.env.json
@@ -1,6 +1,11 @@
 {
-  "KeyLocation": "certs/key.pem",
-  "CertLocation": "certs/cert.pem",
-  "Port": ":5000",
-  "WebFileLocation": "./webdist"
+  "Server": {
+    "KeyLocation": "certs/key.pem",
+    "CertLocation": "certs/cert.pem",
+    "Port": ":5000",
+    "WebFileLocation": "./webdist"
+  }, 
+  "Logger": {
+    "LogFileLocation": "./logs"
+  }
 }

--- a/server/cmd/server.go
+++ b/server/cmd/server.go
@@ -8,6 +8,7 @@ import (
 	"github.com/darwinfroese/hacksite/server/pkg/api"
 	"github.com/darwinfroese/hacksite/server/pkg/config"
 	"github.com/darwinfroese/hacksite/server/pkg/database/bolt"
+	"github.com/darwinfroese/hacksite/server/pkg/log/logrus"
 	"github.com/darwinfroese/hacksite/server/pkg/scheduler"
 )
 
@@ -22,37 +23,40 @@ var (
 // TODO: Receive arguments to gracefully shutdown the server
 
 func main() {
-	fmt.Println("Setting up the server.")
 
-	// Redirect *:80 to *:443
-	go http.ListenAndServe(":80", http.HandlerFunc(api.RedirectToHTTPS))
-
+	// Setup
 	m := http.NewServeMux()
 	db := bolt.New()
 	c := config.ParseConfig(envFile)
+	logger := logrus.New(c.Logger.LogFileLocation)
 
-	ctx := api.Context{DB: &db, Config: &c}
+	ctx := api.Context{DB: &db, Config: &c, Logger: &logger}
 
-	m.Handle("/", http.FileServer(http.Dir(c.WebFileLocation)))
+	logger.Info("Starting redirect server")
+	// Redirect *:80 to *:443
+	go http.ListenAndServe(":80", http.HandlerFunc(api.RedirectToHTTPS))
+	m.Handle("/", http.FileServer(http.Dir(c.Server.WebFileLocation)))
 
 	api.RegisterRoutes(m)
-	api.RegisterAPIRoutes(ctx, m)
+	api.RegisterAPIRoutes(&ctx, m)
 
-	fmt.Println("Starting server scheduler.")
+	logger.Info("Starting scheduler")
 	scheduler.Start(ctx)
 
-	if _, err := os.Stat(c.CertLocation); os.IsNotExist(err) {
-		fmt.Println("Couldn't find: ", c.CertLocation)
+	if _, err := os.Stat(c.Server.CertLocation); os.IsNotExist(err) {
+		logger.Error(fmt.Sprintf("Couldn't find %s", c.Server.CertLocation))
+		return
 	}
 
-	if _, err := os.Stat(c.KeyLocation); os.IsNotExist(err) {
-		fmt.Println("Couldn't find: ", c.KeyLocation)
+	if _, err := os.Stat(c.Server.KeyLocation); os.IsNotExist(err) {
+		logger.Error(fmt.Sprintf("Couldn't find %s", c.Server.KeyLocation))
+		return
 	}
 
-	fmt.Println("Starting the server.")
-	fmt.Println("Server failed with: ", http.ListenAndServeTLS(
-		c.Port,
-		c.CertLocation,
-		c.KeyLocation,
-		m))
+	logger.Info("Starting api server.")
+	logger.Error(fmt.Sprintf("Server failed with %s", http.ListenAndServeTLS(
+		c.Server.Port,
+		c.Server.CertLocation,
+		c.Server.KeyLocation,
+		m)))
 }

--- a/server/models/models.go
+++ b/server/models/models.go
@@ -52,11 +52,7 @@ type Session struct {
 	Expiration time.Time
 }
 
-// ServerConfig contains server configuration settings
-type ServerConfig struct {
-	Port, KeyLocation, CertLocation, WebFileLocation string
-}
-
+// ResponseObject is a wrapper for responding to error requests
 type ResponseObject struct {
 	StatusCode   int
 	ErrorMessage string

--- a/server/pkg/accounts/accounts.go
+++ b/server/pkg/accounts/accounts.go
@@ -3,12 +3,12 @@ package accounts
 import (
 	"errors"
 	"fmt"
-	"os"
 	"reflect"
 
 	"github.com/darwinfroese/hacksite/server/models"
 	"github.com/darwinfroese/hacksite/server/pkg/auth"
 	"github.com/darwinfroese/hacksite/server/pkg/database"
+	"github.com/darwinfroese/hacksite/server/pkg/log"
 )
 
 const (
@@ -16,12 +16,12 @@ const (
 )
 
 // CreateAccount will create an account and insert it into the database
-func CreateAccount(db database.Database, account *models.Account) error {
+func CreateAccount(db database.Database, logger log.Logger, account *models.Account) error {
 
 	//Check if the username already exists
 	acc, err := db.GetAccountByUsername(account.Username)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error getting account: %s\n", err.Error())
+		logger.Error(fmt.Sprintf("Error getting account: %s", err.Error()))
 		return err
 	}
 	if !reflect.DeepEqual(acc, (models.Account{})) {
@@ -31,7 +31,7 @@ func CreateAccount(db database.Database, account *models.Account) error {
 	//Check if the email already exists
 	acc, err = db.GetAccountByEmail(account.Email)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error getting account: %s\n", err.Error())
+		logger.Error(fmt.Sprintf("Error getting account: %s\n", err.Error()))
 		return err
 	}
 	if !reflect.DeepEqual(acc, (models.Account{})) {
@@ -52,7 +52,7 @@ func CreateAccount(db database.Database, account *models.Account) error {
 	account.Salt = salt
 	id, err := db.GetNextAccountID()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %s\n", err.Error())
+		logger.Error(fmt.Sprintf("Error: %s\n", err.Error()))
 		return err
 	}
 

--- a/server/pkg/accounts/accounts_test.go
+++ b/server/pkg/accounts/accounts_test.go
@@ -6,17 +6,20 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/darwinfroese/hacksite/server/models"
 	"github.com/darwinfroese/hacksite/server/pkg/database"
 	"github.com/darwinfroese/hacksite/server/pkg/database/bolt"
-
-	"github.com/darwinfroese/hacksite/server/models"
+	"github.com/darwinfroese/hacksite/server/pkg/log"
+	"github.com/darwinfroese/hacksite/server/pkg/log/testLogger"
 )
 
 var db database.Database
+var logger log.Logger
 
 // TestMain lets us setup the database and then remove it when we are done
 func TestMain(m *testing.M) {
 	db = bolt.New()
+	logger = testLogger.New()
 
 	retCode := m.Run()
 
@@ -111,7 +114,7 @@ func TestCreateAccount(t *testing.T) {
 
 	for i, tc := range createAccountTests {
 		t.Logf("[ %02d ] %s\n", i+1, tc.Description)
-		err := CreateAccount(db, &tc.Account)
+		err := CreateAccount(db, logger, &tc.Account)
 
 		if err != nil && err.Error() != tc.ExpectedErrorMessage {
 			t.Errorf("[ FAIL ] The test failed because of an unexpected error: %s\n", err.Error())

--- a/server/pkg/api/context.go
+++ b/server/pkg/api/context.go
@@ -1,13 +1,15 @@
 package api
 
 import (
-	"github.com/darwinfroese/hacksite/server/models"
+	"github.com/darwinfroese/hacksite/server/pkg/config"
 	"github.com/darwinfroese/hacksite/server/pkg/database"
+	"github.com/darwinfroese/hacksite/server/pkg/log"
 )
 
 // Context stores values used by all handlers
 type Context struct {
+	Logger    *log.Logger
 	DB        *database.Database
-	Config    *models.ServerConfig
+	Config    *config.EnvironmentConfig
 	RequestID string
 }

--- a/server/pkg/api/iterationHandlers.go
+++ b/server/pkg/api/iterationHandlers.go
@@ -2,9 +2,7 @@ package api
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
-	"os"
 
 	"github.com/darwinfroese/hacksite/server/models"
 	"github.com/darwinfroese/hacksite/server/pkg/iterations"
@@ -18,28 +16,28 @@ var currIterHandlersMap = map[string]handler{
 	"POST": switchIteration,
 }
 
-func (ctx Context) iterationsRoute(w http.ResponseWriter, r *http.Request) {
+func (ctx *Context) iterationsRoute(w http.ResponseWriter, r *http.Request) {
 	callHandler(ctx, w, r, iterHandlersMap)
 }
 
-func (ctx Context) currentIterationRoute(w http.ResponseWriter, r *http.Request) {
+func (ctx *Context) currentIterationRoute(w http.ResponseWriter, r *http.Request) {
 	callHandler(ctx, w, r, currIterHandlersMap)
 }
 
-func addIteration(ctx Context, w http.ResponseWriter, r *http.Request) {
+func addIteration(ctx *Context, w http.ResponseWriter, r *http.Request) {
 	var iteration models.Iteration
 	err := json.NewDecoder(r.Body).Decode(&iteration)
 
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %s\n", err.Error())
+		(*ctx.Logger).ErrorWithRequest(r, ctx.RequestID, err.Error())
 		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 		return
 	}
 
-	project, err := iterations.CreateIteration(*ctx.DB, iteration)
+	project, err := iterations.CreateIteration(*ctx.DB, *ctx.Logger, iteration)
 
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %s\n", err.Error())
+		(*ctx.Logger).ErrorWithRequest(r, ctx.RequestID, err.Error())
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
@@ -47,19 +45,19 @@ func addIteration(ctx Context, w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(project)
 }
 
-func switchIteration(ctx Context, w http.ResponseWriter, r *http.Request) {
+func switchIteration(ctx *Context, w http.ResponseWriter, r *http.Request) {
 	var iteration models.Iteration
 	err := json.NewDecoder(r.Body).Decode(&iteration)
 
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %s\n", err.Error())
+		(*ctx.Logger).ErrorWithRequest(r, ctx.RequestID, err.Error())
 		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 		return
 	}
 
-	project, err := iterations.SwapCurrentIteration(*ctx.DB, iteration)
+	project, err := iterations.SwapCurrentIteration(*ctx.DB, *ctx.Logger, iteration)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %s\n", err.Error())
+		(*ctx.Logger).ErrorWithRequest(r, ctx.RequestID, err.Error())
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}

--- a/server/pkg/api/routes.go
+++ b/server/pkg/api/routes.go
@@ -16,7 +16,7 @@ var writeMethods = []string{"POST", "OPTIONS"}
 // TODO: Implement logging
 
 // RegisterAPIRoutes registers all the api routes into the mux
-func RegisterAPIRoutes(ctx Context, mux *http.ServeMux) {
+func RegisterAPIRoutes(ctx *Context, mux *http.ServeMux) {
 	mux.HandleFunc(apiPrefix+"/projects", Apply(ctx, ctx.projectsRoute))
 	mux.HandleFunc(apiPrefix+"/project", Apply(ctx, ctx.projectRoute))
 	mux.HandleFunc(apiPrefix+"/tasks", Apply(ctx, ctx.tasksRoute))
@@ -30,5 +30,5 @@ func RegisterAPIRoutes(ctx Context, mux *http.ServeMux) {
 
 // RegisterRoutes registers all non api routes into the mux
 func RegisterRoutes(mux *http.ServeMux) {
-	mux.Handle("/health", setCorsHeaders(Context{}, http.HandlerFunc(healthCheckHandler)))
+	mux.Handle("/health", setCorsHeaders(nil, http.HandlerFunc(healthCheckHandler)))
 }

--- a/server/pkg/api/sessionHandlers.go
+++ b/server/pkg/api/sessionHandlers.go
@@ -1,9 +1,7 @@
 package api
 
 import (
-	"fmt"
 	"net/http"
-	"os"
 	"time"
 
 	"github.com/darwinfroese/hacksite/server/pkg/auth"
@@ -13,19 +11,19 @@ var sessionHandlersMap = map[string]handler{
 	"GET": sessionHandler,
 }
 
-func (ctx Context) sessionRoute(w http.ResponseWriter, r *http.Request) {
+func (ctx *Context) sessionRoute(w http.ResponseWriter, r *http.Request) {
 	callHandler(ctx, w, r, sessionHandlersMap)
 }
 
-func sessionHandler(ctx Context, w http.ResponseWriter, r *http.Request) {
-	session, err := auth.GetCurrentSession(*ctx.DB, r)
+func sessionHandler(ctx *Context, w http.ResponseWriter, r *http.Request) {
+	session, err := auth.GetCurrentSession(*ctx.DB, *ctx.Logger, r)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %s\n", err.Error())
+		(*ctx.Logger).ErrorWithRequest(r, ctx.RequestID, err.Error())
 		http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 		return
 	}
 	if time.Now().After(session.Expiration) {
-		fmt.Println(err.Error())
+		(*ctx.Logger).ErrorWithRequest(r, ctx.RequestID, "Session was expired")
 		http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 		return
 	}
@@ -33,6 +31,7 @@ func sessionHandler(ctx Context, w http.ResponseWriter, r *http.Request) {
 	session.Expiration = time.Now().Add(time.Second * auth.SessionMaxAge)
 	err = (*ctx.DB).StoreSession(session)
 	if err != nil {
+		(*ctx.Logger).ErrorWithRequest(r, ctx.RequestID, err.Error())
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}

--- a/server/pkg/api/taskHandlers.go
+++ b/server/pkg/api/taskHandlers.go
@@ -2,9 +2,7 @@ package api
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
-	"os"
 
 	"github.com/darwinfroese/hacksite/server/models"
 	"github.com/darwinfroese/hacksite/server/pkg/tasks"
@@ -16,12 +14,12 @@ var taskHandlersMap = map[string]handler{
 	"DELETE": removeTask,
 }
 
-func (ctx Context) tasksRoute(w http.ResponseWriter, r *http.Request) {
+func (ctx *Context) tasksRoute(w http.ResponseWriter, r *http.Request) {
 	callHandler(ctx, w, r, taskHandlersMap)
 }
 
 // Handlers for specific methods on /tasks
-func updateTask(ctx Context, w http.ResponseWriter, r *http.Request) {
+func updateTask(ctx *Context, w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Origin", "http://localhost:8080")
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Access-Control-Allow-Credentials", "true")
@@ -29,13 +27,14 @@ func updateTask(ctx Context, w http.ResponseWriter, r *http.Request) {
 	var task models.Task
 	err := json.NewDecoder(r.Body).Decode(&task)
 	if err != nil {
+		(*ctx.Logger).ErrorWithRequest(r, ctx.RequestID, err.Error())
 		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 		return
 	}
 
-	project, err := tasks.UpdateTask(*ctx.DB, task)
+	project, err := tasks.UpdateTask(*ctx.DB, *ctx.Logger, task)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %s\n", err.Error())
+		(*ctx.Logger).ErrorWithRequest(r, ctx.RequestID, err.Error())
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
@@ -43,7 +42,7 @@ func updateTask(ctx Context, w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(project)
 }
 
-func removeTask(ctx Context, w http.ResponseWriter, r *http.Request) {
+func removeTask(ctx *Context, w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Origin", "http://localhost:8080")
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Access-Control-Allow-Credentials", "true")
@@ -52,13 +51,14 @@ func removeTask(ctx Context, w http.ResponseWriter, r *http.Request) {
 	err := json.NewDecoder(r.Body).Decode(&task)
 
 	if err != nil {
+		(*ctx.Logger).ErrorWithRequest(r, ctx.RequestID, err.Error())
 		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 		return
 	}
 
-	project, err := tasks.RemoveTask(*ctx.DB, task)
+	project, err := tasks.RemoveTask(*ctx.DB, *ctx.Logger, task)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %s\n", err.Error())
+		(*ctx.Logger).ErrorWithRequest(r, ctx.RequestID, err.Error())
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}

--- a/server/pkg/api/utilHandlers.go
+++ b/server/pkg/api/utilHandlers.go
@@ -3,7 +3,6 @@ package api
 import (
 	"fmt"
 	"net/http"
-	"os"
 )
 
 // RedirectToHTTPS will take the request coming in on *:80 and forward it to *:443
@@ -14,7 +13,6 @@ func RedirectToHTTPS(w http.ResponseWriter, r *http.Request) {
 		target += "?" + r.URL.RawQuery
 	}
 
-	fmt.Fprintf(os.Stdout, "Redirecting to: %s\n", target)
 	http.Redirect(w, r, target, http.StatusTemporaryRedirect)
 }
 
@@ -24,6 +22,7 @@ func healthCheckHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // unsupportedMethodHandler is a default handler that will send a 405 error
-func unsupportedMethodHandler(ctx Context, w http.ResponseWriter, r *http.Request) {
+func unsupportedMethodHandler(ctx *Context, w http.ResponseWriter, r *http.Request) {
+	(*ctx.Logger).ErrorWithRequest(r, ctx.RequestID, "Method not allowed on endpoint")
 	http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
 }

--- a/server/pkg/api/utils.go
+++ b/server/pkg/api/utils.go
@@ -10,13 +10,13 @@ const (
 	supportedHeaders = "Content-Type, Authorization"
 )
 
-type handler func(Context, http.ResponseWriter, *http.Request)
+type handler func(*Context, http.ResponseWriter, *http.Request)
 
 func methodsToString(methods []string) string {
 	return strings.Join(methods, ", ")
 }
 
-func callHandler(ctx Context, w http.ResponseWriter, r *http.Request, m map[string]handler) {
+func callHandler(ctx *Context, w http.ResponseWriter, r *http.Request, m map[string]handler) {
 	if h, ok := m[r.Method]; ok {
 		h(ctx, w, r)
 	} else {

--- a/server/pkg/auth/auth.go
+++ b/server/pkg/auth/auth.go
@@ -6,11 +6,11 @@ import (
 	"encoding/base64"
 	"fmt"
 	"net/http"
-	"os"
 	"time"
 
 	"github.com/darwinfroese/hacksite/server/models"
 	"github.com/darwinfroese/hacksite/server/pkg/database"
+	"github.com/darwinfroese/hacksite/server/pkg/log"
 )
 
 const sessionTokenSize = 64
@@ -94,11 +94,11 @@ func SetCookie(w http.ResponseWriter, name, token string) {
 }
 
 // GetCurrentSession reads the session cookie and grabs the session associated
-func GetCurrentSession(db database.Database, r *http.Request) (models.Session, error) {
+func GetCurrentSession(db database.Database, logger log.Logger, r *http.Request) (models.Session, error) {
 	cookie, err := r.Cookie(SessionCookieName)
 
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %s\n", err.Error())
+		logger.Error(fmt.Sprintf("Error: %s\n", err.Error()))
 		return models.Session{}, err
 	}
 

--- a/server/pkg/config/config.go
+++ b/server/pkg/config/config.go
@@ -5,16 +5,27 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-
-	"github.com/darwinfroese/hacksite/server/models"
 )
+
+// EnvironmentConfig contains the configuration for the enivornment
+type EnvironmentConfig struct {
+	Server serverConfig
+	Logger logConfig
+}
+
+type serverConfig struct {
+	Port, KeyLocation, CertLocation, WebFileLocation string
+}
+type logConfig struct {
+	LogFileLocation string
+}
 
 // ParseConfig reads the environmentconfig file and converts it into a struct
 // that can be used to setup the server
-func ParseConfig(environmentFile string) models.ServerConfig {
-	var config models.ServerConfig
+func ParseConfig(environmentFile string) EnvironmentConfig {
+	var config EnvironmentConfig
 
-	fmt.Fprintf(os.Stdout, "Using config file: %s\n", environmentFile)
+	fmt.Printf("Using config file: %s\n", environmentFile)
 
 	if _, err := os.Stat(environmentFile); os.IsNotExist(err) {
 		fmt.Fprintf(os.Stderr, "Couldn't find the file: %s\n", environmentFile)

--- a/server/pkg/iterations/iterations.go
+++ b/server/pkg/iterations/iterations.go
@@ -2,21 +2,19 @@ package iterations
 
 import (
 	"errors"
-	"fmt"
-	"os"
 	"reflect"
-
-	"github.com/darwinfroese/hacksite/server/pkg/projects"
 
 	"github.com/darwinfroese/hacksite/server/models"
 	"github.com/darwinfroese/hacksite/server/pkg/database"
+	"github.com/darwinfroese/hacksite/server/pkg/log"
+	"github.com/darwinfroese/hacksite/server/pkg/projects"
 )
 
 // CreateIteration creates a new iteration and stores it in the database
-func CreateIteration(db database.Database, iteration models.Iteration) (models.Project, error) {
+func CreateIteration(db database.Database, logger log.Logger, iteration models.Iteration) (models.Project, error) {
 	project, err := db.GetProject(iteration.ProjectID)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %s\n", err.Error())
+		logger.Error(err.Error())
 		return project, err
 	}
 
@@ -25,7 +23,7 @@ func CreateIteration(db database.Database, iteration models.Iteration) (models.P
 
 	err = projects.UpdateProject(db, &project)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %s\n", err.Error())
+		logger.Error(err.Error())
 		return project, err
 	}
 
@@ -33,10 +31,10 @@ func CreateIteration(db database.Database, iteration models.Iteration) (models.P
 }
 
 // SwapCurrentIteration swaps the current iteration for a project
-func SwapCurrentIteration(db database.Database, iteration models.Iteration) (models.Project, error) {
+func SwapCurrentIteration(db database.Database, logger log.Logger, iteration models.Iteration) (models.Project, error) {
 	project, err := db.GetProject(iteration.ProjectID)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %s\n", err.Error())
+		logger.Error(err.Error())
 		return project, err
 	}
 
@@ -49,7 +47,7 @@ func SwapCurrentIteration(db database.Database, iteration models.Iteration) (mod
 	project.CurrentIteration = iteration
 	err = projects.UpdateProject(db, &project)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %s\n", err.Error())
+		logger.Error(err.Error())
 		return project, err
 	}
 

--- a/server/pkg/iterations/iterations_test.go
+++ b/server/pkg/iterations/iterations_test.go
@@ -9,9 +9,12 @@ import (
 	"github.com/darwinfroese/hacksite/server/models"
 	"github.com/darwinfroese/hacksite/server/pkg/database"
 	"github.com/darwinfroese/hacksite/server/pkg/database/bolt"
+	"github.com/darwinfroese/hacksite/server/pkg/log"
+	"github.com/darwinfroese/hacksite/server/pkg/log/testLogger"
 )
 
 var db database.Database
+var logger log.Logger
 
 var testProject = models.Project{
 	Name:             "Test Project",
@@ -20,6 +23,7 @@ var testProject = models.Project{
 
 func TestMain(m *testing.M) {
 	db = bolt.New()
+	logger = testLogger.New()
 	err := db.AddProject(testProject)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Couldn't add the project to setup the tests: %s\n", err.Error())
@@ -64,7 +68,7 @@ func TestCreateIteration(t *testing.T) {
 	for i, tc := range createIterationTests {
 		t.Logf("[ %02d ] %s\n", i+1, tc.Description)
 
-		project, err := CreateIteration(db, tc.NewIteration)
+		project, err := CreateIteration(db, logger, tc.NewIteration)
 		if err != nil {
 			t.Errorf("[ FAIL ] Couldn't create the iteration: %s\n", err.Error())
 		}
@@ -115,7 +119,7 @@ func TestSwapCurrentIteration(t *testing.T) {
 	for i, tc := range swapIterationsTests {
 		t.Logf("[ %02d ] %s\n", i+1, tc.Description)
 
-		project, err := SwapCurrentIteration(db, tc.SwapIteration)
+		project, err := SwapCurrentIteration(db, logger, tc.SwapIteration)
 		if err != nil && err.Error() != models.InvalidIterationErrorMessage {
 			t.Errorf("[ FAIL ] Couldn't swap the current iteration: %s\n", err.Error())
 		}

--- a/server/pkg/log/log.go
+++ b/server/pkg/log/log.go
@@ -1,0 +1,13 @@
+package log
+
+import "net/http"
+
+// Logger is a simple logging interface for outputting
+// messages to log files
+type Logger interface {
+	Info(string)
+	Error(string)
+
+	ErrorWithRequest(request *http.Request, requestID string, message string)
+	InfoWithRequest(request *http.Request, requestID string, message string)
+}

--- a/server/pkg/log/logrus/logrus.go
+++ b/server/pkg/log/logrus/logrus.go
@@ -1,0 +1,128 @@
+package logrus
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/darwinfroese/hacksite/server/pkg/log"
+	"github.com/sirupsen/logrus"
+)
+
+var fileLock = &sync.Mutex{}
+
+type logrusLogger struct {
+	logger      *logrus.Logger
+	logLocation string
+}
+
+// New returns a new logrus logger
+func New(location string) log.Logger {
+	return &logrusLogger{
+		logger:      logrus.New(),
+		logLocation: location,
+	}
+}
+
+func (l *logrusLogger) ErrorWithRequest(r *http.Request, id, message string) {
+	fileLock.Lock()
+
+	file := getFile(l.logLocation)
+	l.logger.Out = file
+	defer func() {
+		file.Close()
+		fileLock.Unlock()
+	}()
+
+	l.logger.WithFields(logrus.Fields{
+		"request-id":   id,
+		"request-url":  r.URL.Path,
+		"user-agent":   r.UserAgent(),
+		"user-address": r.RemoteAddr,
+		"calling-func": getCallingFunction(),
+	}).Error(message)
+}
+
+func (l *logrusLogger) InfoWithRequest(r *http.Request, id, message string) {
+	fileLock.Lock()
+
+	file := getFile(l.logLocation)
+	l.logger.Out = file
+	defer func() {
+		file.Close()
+		fileLock.Unlock()
+	}()
+
+	l.logger.WithFields(logrus.Fields{
+		"request-id":   id,
+		"request-url":  r.URL.Path,
+		"user-agent":   r.UserAgent(),
+		"user-address": r.RemoteAddr,
+		"calling-func": getCallingFunction(),
+	}).Info(message)
+}
+
+func (l *logrusLogger) Info(message string) {
+	fileLock.Lock()
+
+	file := getFile(l.logLocation)
+	l.logger.Out = file
+	defer func() {
+		file.Close()
+		fileLock.Unlock()
+	}()
+
+	l.logger.WithFields(logrus.Fields{
+		"calling-func": getCallingFunction(),
+	}).Info(message)
+}
+
+func (l *logrusLogger) Error(message string) {
+	fileLock.Lock()
+
+	file := getFile(l.logLocation)
+	l.logger.Out = file
+	defer func() {
+		file.Close()
+		fileLock.Unlock()
+	}()
+
+	l.logger.WithFields(logrus.Fields{
+		"calling-func": getCallingFunction(),
+	}).Error(message)
+}
+
+func getFile(location string) *os.File {
+	d := time.Now().Format("02012006")
+	fn := fmt.Sprintf("%s/%s.log", location, d)
+
+	file, err := os.OpenFile(fn, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		return os.Stderr
+	}
+
+	return file
+}
+
+func getCallingFunction() string {
+	// we get the callers as uintptrs - but we just need 1
+	fpcs := make([]uintptr, 1)
+
+	// skip 3 levels to get to the caller of whoever called Caller()
+	n := runtime.Callers(3, fpcs)
+	if n == 0 {
+		return "unknown" // proper error her would be better
+	}
+
+	// get the info of the actual function that's in the pointer
+	fun := runtime.FuncForPC(fpcs[0] - 1)
+	if fun == nil {
+		return "unknown"
+	}
+
+	// return its name
+	return fun.Name()
+}

--- a/server/pkg/log/testLogger/testLogger.go
+++ b/server/pkg/log/testLogger/testLogger.go
@@ -1,0 +1,33 @@
+package testLogger
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/darwinfroese/hacksite/server/pkg/log"
+)
+
+type testLogger struct {
+}
+
+// New creates a new test logger
+func New() log.Logger {
+	return &testLogger{}
+}
+
+func (l *testLogger) Info(message string) {
+	fmt.Fprintf(os.Stdout, "%s\n", message)
+}
+
+func (l *testLogger) Error(message string) {
+	fmt.Fprintf(os.Stderr, "%s\n", message)
+}
+
+func (l *testLogger) InfoWithRequest(r *http.Request, requestID, message string) {
+	fmt.Fprintf(os.Stderr, "%s\n", message)
+}
+
+func (l *testLogger) ErrorWithRequest(r *http.Request, requestID, message string) {
+	fmt.Fprintf(os.Stderr, "%s\n", message)
+}

--- a/server/pkg/projects/projects_test.go
+++ b/server/pkg/projects/projects_test.go
@@ -8,9 +8,12 @@ import (
 	"github.com/darwinfroese/hacksite/server/models"
 	"github.com/darwinfroese/hacksite/server/pkg/database"
 	"github.com/darwinfroese/hacksite/server/pkg/database/bolt"
+	"github.com/darwinfroese/hacksite/server/pkg/log"
+	"github.com/darwinfroese/hacksite/server/pkg/log/testLogger"
 )
 
 var db database.Database
+var logger log.Logger
 var testSession = models.Session{
 	Token:  "TestSession",
 	UserID: 1,
@@ -18,6 +21,7 @@ var testSession = models.Session{
 
 func TestMain(m *testing.M) {
 	db = bolt.New()
+	logger = testLogger.New()
 	db.CreateAccount(models.Account{
 		ID: 1,
 	})
@@ -57,7 +61,7 @@ func TestCreateProject(t *testing.T) {
 	for i, tc := range createProjectTests {
 		t.Logf("[ %02d ] %s\n", i+1, tc.Description)
 
-		err := CreateProject(db, &tc.ProjectToCreate, testSession.UserID)
+		err := CreateProject(db, logger, &tc.ProjectToCreate, testSession.UserID)
 		if err != nil {
 			t.Errorf("[ FAIL ] An unexpected error occured creating the project: %s\n", err.Error())
 		}
@@ -85,7 +89,7 @@ func TestGetUserProjects(t *testing.T) {
 	for i, tc := range getUserProjectsTests {
 		t.Logf("[ %02d ] %s\n", i+1, tc.Description)
 
-		projects, err := GetUserProjects(db, testSession.UserID)
+		projects, err := GetUserProjects(db, logger, testSession.UserID)
 		if err != nil {
 			t.Errorf("[ FAIL ] An unexpected error getting the projects for a user: %s\n", err.Error())
 		}
@@ -184,7 +188,7 @@ func TestDeleteProject(t *testing.T) {
 	for i, tc := range deleteProjectTests {
 		t.Logf("[ %02d ] %s\n", i+1, tc.Description)
 
-		err := DeleteProject(db, testSession.UserID, tc.ProjectIDToRemove)
+		err := DeleteProject(db, logger, testSession.UserID, tc.ProjectIDToRemove)
 		if err != nil {
 			t.Errorf("[ FAIL ] An unexpected error occurred deleting the project: %s.\n", err.Error())
 		}

--- a/server/pkg/scheduler/scheduler.go
+++ b/server/pkg/scheduler/scheduler.go
@@ -2,11 +2,11 @@ package scheduler
 
 import (
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/darwinfroese/hacksite/server/pkg/api"
 	"github.com/darwinfroese/hacksite/server/pkg/database"
+	"github.com/darwinfroese/hacksite/server/pkg/log"
 )
 
 // Start executes the scheduler that will run tasks periodically in the background
@@ -16,24 +16,24 @@ func Start(ctx api.Context) {
 	go func() {
 		for range ticker.C {
 			// TODO: These should be logs
-			count, err := cleanSessions(*ctx.DB)
+			count, err := cleanSessions(*ctx.DB, *ctx.Logger)
 
 			if err != nil {
-				fmt.Printf("[ERROR] An error occured trying to clean sessions from the database: %s\n", err.Error())
+				(*ctx.Logger).Error(fmt.Sprintf("Attempting to clean sessions from database: %s", err.Error()))
 			} else {
-				fmt.Printf("[INFO] Removed %d expired sessions\n", count)
+				(*ctx.Logger).Info(fmt.Sprintf("Removed %d expired sessions", count))
 			}
 		}
 	}()
 }
 
 // cleanSessions grabs all the sessions from the database and removes the ones that are expired
-func cleanSessions(db database.Database) (int, error) {
+func cleanSessions(db database.Database, logger log.Logger) (int, error) {
 	count := 0
 
 	sessions, err := db.GetAllSessions()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %s\n", err.Error())
+		logger.Error(err.Error())
 		return count, err
 	}
 
@@ -42,7 +42,7 @@ func cleanSessions(db database.Database) (int, error) {
 			err = db.RemoveSession(sesh.Token)
 			if err != nil {
 				// since this is just removing one at a time we can continue on if one fails
-				fmt.Fprintf(os.Stderr, "Error: %s\n", err.Error())
+				logger.Error(err.Error())
 			} else {
 				count++
 			}

--- a/server/pkg/scheduler/sessions_test.go
+++ b/server/pkg/scheduler/sessions_test.go
@@ -5,10 +5,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/darwinfroese/hacksite/server/models"
 	"github.com/darwinfroese/hacksite/server/pkg/database"
 	"github.com/darwinfroese/hacksite/server/pkg/database/bolt"
-
-	"github.com/darwinfroese/hacksite/server/models"
+	"github.com/darwinfroese/hacksite/server/pkg/log"
+	"github.com/darwinfroese/hacksite/server/pkg/log/testLogger"
 )
 
 var expiredSession = models.Session{
@@ -23,9 +24,11 @@ var unexpiredSession = models.Session{
 }
 
 var db database.Database
+var logger log.Logger
 
 func TestMain(m *testing.M) {
 	db = bolt.New()
+	logger = testLogger.New()
 	db.StoreSession(expiredSession)
 	db.StoreSession(unexpiredSession)
 
@@ -52,7 +55,7 @@ func TestCleanSessions(t *testing.T) {
 	for i, tc := range sessionTests {
 		t.Logf("[ %02d ] %s\n", i+1, tc.Description)
 
-		count, err := cleanSessions(db)
+		count, err := cleanSessions(db, logger)
 		if err != nil {
 			t.Errorf("[ FAIL ] An error occured trying to remove expried sessions: %s\n", err.Error())
 		}

--- a/server/pkg/tasks/tasks.go
+++ b/server/pkg/tasks/tasks.go
@@ -1,19 +1,17 @@
 package tasks
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/darwinfroese/hacksite/server/models"
 	"github.com/darwinfroese/hacksite/server/pkg/database"
+	"github.com/darwinfroese/hacksite/server/pkg/log"
 	"github.com/darwinfroese/hacksite/server/pkg/projects"
 )
 
 // UpdateTask updates a task in a project and pushes the change into the database
-func UpdateTask(db database.Database, task models.Task) (models.Project, error) {
+func UpdateTask(db database.Database, logger log.Logger, task models.Task) (models.Project, error) {
 	project, err := db.GetProject(task.ProjectID)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error Getting Project: %s\n", err.Error())
+		logger.Error(err.Error())
 		return project, err
 	}
 
@@ -37,7 +35,7 @@ func UpdateTask(db database.Database, task models.Task) (models.Project, error) 
 
 	err = db.UpdateProject(project)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error Updating Project: %s\n", err.Error())
+		logger.Error(err.Error())
 		return project, err
 	}
 
@@ -45,10 +43,10 @@ func UpdateTask(db database.Database, task models.Task) (models.Project, error) 
 }
 
 // RemoveTask removes a task from a project and pushes the change into the database
-func RemoveTask(db database.Database, task models.Task) (models.Project, error) {
+func RemoveTask(db database.Database, logger log.Logger, task models.Task) (models.Project, error) {
 	project, err := db.GetProject(task.ProjectID)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %s\n", err.Error())
+		logger.Error(err.Error())
 		return project, err
 	}
 
@@ -72,7 +70,7 @@ func RemoveTask(db database.Database, task models.Task) (models.Project, error) 
 
 	err = projects.UpdateProject(db, &project)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %s\n", err.Error())
+		logger.Error(err.Error())
 		return project, err
 	}
 

--- a/server/pkg/tasks/tasks_test.go
+++ b/server/pkg/tasks/tasks_test.go
@@ -8,9 +8,12 @@ import (
 	"github.com/darwinfroese/hacksite/server/models"
 	"github.com/darwinfroese/hacksite/server/pkg/database"
 	"github.com/darwinfroese/hacksite/server/pkg/database/bolt"
+	"github.com/darwinfroese/hacksite/server/pkg/log"
+	"github.com/darwinfroese/hacksite/server/pkg/log/testLogger"
 )
 
 var db database.Database
+var logger log.Logger
 var testProject = models.Project{
 	Name: "Test Project",
 	CurrentIteration: models.Iteration{
@@ -24,6 +27,7 @@ var testProject = models.Project{
 
 func TestMain(m *testing.M) {
 	db = bolt.New()
+	logger = testLogger.New()
 
 	retCode := m.Run()
 
@@ -84,7 +88,7 @@ func TestUpdateTask(t *testing.T) {
 	for i, tc := range updateTaskTests {
 		t.Logf("[ %02d ] %s\n", i+1, tc.Description)
 
-		proj, err := UpdateTask(db, tc.NewTask)
+		proj, err := UpdateTask(db, logger, tc.NewTask)
 		if err != nil {
 			t.Errorf("[ FAIL ] An error occured updating the task: %s\n", err.Error())
 		}
@@ -144,7 +148,7 @@ func TestRemoveTask(t *testing.T) {
 	for i, tc := range removeTaskTests {
 		t.Logf("[ %02d ] %s\n", i+1, tc.Description)
 
-		proj, err := RemoveTask(db, tc.TaskToRemove)
+		proj, err := RemoveTask(db, logger, tc.TaskToRemove)
 		if err != nil {
 			t.Errorf("[ FAIL ] An error occured updating the task: %s\n", err.Error())
 		}

--- a/webclient/build/webpack.prod.conf.js
+++ b/webclient/build/webpack.prod.conf.js
@@ -33,7 +33,9 @@ var webpackConfig = merge(baseWebpackConfig, {
     }),
     new webpack.optimize.UglifyJsPlugin({
       compress: {
-        warnings: false
+        warnings: false,
+        drop_console: true,
+        drop_debugger: true
       },
       sourceMap: true
     }),


### PR DESCRIPTION
# Implement Logging Service

Implemented a logger to replace scattered `fmt` calls

### Notes
- logrus can be used in production code to log
- have 2 calls for each `Info` and `Error` level logging
    - with request will log `{ request-id, request-url, user-agent, user-id, calling-function, message }'
    - info/error will log `{message, calling-function }`
- TestLogger will just spit the message to the console and can be used for testing
- logger is added to the context
- as many `fmt` calls that can be replaced by `logrus` have been
- updated config to have sections including the log file location for the logger

@darwinfroese
