### PR TITLE
removed project id title

### DIFF
--- a/webclient/src/components/views/Edit.vue
+++ b/webclient/src/components/views/Edit.vue
@@ -70,7 +70,7 @@ export default {
   },
   computed: {
     editTitle: function () {
-      return 'Edit Project ' + this.project.ID;
+      return 'Edit Project';
     }
   }
 };


### PR DESCRIPTION
# Edit Project Detail Page

This PR:

- [x] Removes the Project ID Title from the project edit page
- [x] Resolves Issue #55 

@darwinfroese

Should the ID just get removed completely or something like `Edit Project »Project Name«` ?